### PR TITLE
Track purchase on thank you page instead

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -23,6 +23,7 @@
         "Sylius\\Component\\Channel\\Model\\ChannelsAwareInterface",
         "Sylius\\Component\\Core\\Model\\OrderInterface",
         "Sylius\\Component\\Core\\OrderPaymentStates",
+        "Sylius\\Component\\Core\\Repository\\OrderRepositoryInterface",
         "Sylius\\Component\\Order\\Model\\OrderInterface",
         "Sylius\\Component\\Order\\Processor\\OrderProcessorInterface"
     ]

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "doctrine/persistence": "^1.3 || ^2.2",
         "knplabs/knp-menu": "^3.1",
         "psr/event-dispatcher": "^1.0",
+        "setono/doctrine-object-manager-trait": "^1.0",
         "sylius/resource-bundle": "^1.6",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/console": "^4.4 || ^5.0",

--- a/src/Exception/WrongOrderTypeException.php
+++ b/src/Exception/WrongOrderTypeException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusGoogleAdsPlugin\Exception;
+
+use Setono\SyliusGoogleAdsPlugin\Model\OrderInterface;
+use Webmozart\Assert\Assert;
+
+final class WrongOrderTypeException
+{
+    /**
+     * @param mixed $order
+     *
+     * @psalm-assert OrderInterface $order
+     */
+    public static function assert($order): void
+    {
+        Assert::isInstanceOf($order, OrderInterface::class, sprintf(
+            'You must implement the %s in your Sylius application. Read the readme here: https://github.com/Setono/SyliusGoogleAdsPlugin',
+            OrderInterface::class
+        ));
+    }
+}

--- a/src/OrderProcessor/SetGoogleClickIdOrderProcessor.php
+++ b/src/OrderProcessor/SetGoogleClickIdOrderProcessor.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Setono\SyliusGoogleAdsPlugin\OrderProcessor;
 
+use Setono\SyliusGoogleAdsPlugin\Exception\WrongOrderTypeException;
 use Setono\SyliusGoogleAdsPlugin\Model\OrderInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Webmozart\Assert\Assert;
 
 final class SetGoogleClickIdOrderProcessor implements OrderProcessorInterface
 {
@@ -27,10 +27,7 @@ final class SetGoogleClickIdOrderProcessor implements OrderProcessorInterface
      */
     public function process(BaseOrderInterface $order): void
     {
-        Assert::isInstanceOf($order, OrderInterface::class, sprintf(
-            'You must implement the %s in your Sylius application. Read the readme here: https://github.com/Setono/SyliusGoogleAdsPlugin',
-            OrderInterface::class
-        ));
+        WrongOrderTypeException::assert($order);
 
         $request = $this->requestStack->getMasterRequest();
         if (null === $request) {

--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="doctrine"/>
             <argument type="service" id="setono_sylius_google_ads.consent_checker.always_given"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="sylius.repository.order"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/tests/Application/config/routes/dev/twig.yaml
+++ b/tests/Application/config/routes/dev/twig.yaml
@@ -1,3 +1,0 @@
-_errors:
-    resource: '@TwigBundle/Resources/config/routing/errors.xml'
-    prefix: /_error


### PR DESCRIPTION
This PR will change the tracking of purchases from the `sylius.order.post_complete` event to the 'thank you' page