### PR TITLE
Add grid for conversions

### DIFF
--- a/src/Controller/Action/RedirectMainMenuAction.php
+++ b/src/Controller/Action/RedirectMainMenuAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusGoogleAdsPlugin\Controller\Action;
+
+use Setono\SyliusGoogleAdsPlugin\Repository\ConnectionRepositoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class RedirectMainMenuAction
+{
+    public function __construct(
+        private readonly ConnectionRepositoryInterface $connectionRepository,
+        private readonly UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function __invoke(Request $request): RedirectResponse
+    {
+        if ($this->connectionRepository->hasAny()) {
+            return new RedirectResponse($this->urlGenerator->generate('setono_sylius_google_ads_admin_conversion_index'));
+        }
+
+        return new RedirectResponse($this->urlGenerator->generate('setono_sylius_google_ads_admin_connection_index'));
+    }
+}

--- a/src/Menu/AdminMenuListener.php
+++ b/src/Menu/AdminMenuListener.php
@@ -26,7 +26,7 @@ final class AdminMenuListener
     {
         $item
             ->addChild('google_ads', [
-                'route' => 'setono_sylius_google_ads_admin_connection_index',
+                'route' => 'setono_sylius_google_ads_admin_redirect_main_menu',
             ])
             ->setLabel('setono_sylius_google_ads.ui.google_ads')
             ->setLabelAttribute('icon', 'money bill alternate outline')

--- a/src/Model/Conversion.php
+++ b/src/Model/Conversion.php
@@ -199,6 +199,11 @@ class Conversion implements ConversionInterface
         $this->logMessages[] = sprintf('[%s] %s', (new \DateTimeImmutable())->format('Y-m-d H:i:s'), $logMessage);
     }
 
+    public function hasLogMessages(): bool
+    {
+        return [] !== $this->logMessages;
+    }
+
     public function getChannel(): ?ChannelInterface
     {
         return $this->channel;

--- a/src/Model/ConversionInterface.php
+++ b/src/Model/ConversionInterface.php
@@ -113,6 +113,8 @@ interface ConversionInterface extends ResourceInterface, TimestampableInterface,
 
     public function addLogMessage(string $logMessage): void;
 
+    public function hasLogMessages(): bool;
+
     public function getChannel(): ?ChannelInterface;
 
     public function setChannel(ChannelInterface $channel): void;

--- a/src/Repository/ConnectionRepository.php
+++ b/src/Repository/ConnectionRepository.php
@@ -8,4 +8,12 @@ use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
 class ConnectionRepository extends EntityRepository implements ConnectionRepositoryInterface
 {
+    public function hasAny(): bool
+    {
+        return (int) $this->createQueryBuilder('o')
+                ->select('COUNT(o)')
+                ->getQuery()
+                ->getSingleScalarResult() > 0
+        ;
+    }
 }

--- a/src/Repository/ConnectionRepositoryInterface.php
+++ b/src/Repository/ConnectionRepositoryInterface.php
@@ -12,4 +12,8 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
  */
 interface ConnectionRepositoryInterface extends RepositoryInterface
 {
+    /**
+     * Returns true if there are 1 or more connections in the database
+     */
+    public function hasAny(): bool;
 }

--- a/src/Resources/config/app/config.yaml
+++ b/src/Resources/config/app/config.yaml
@@ -1,5 +1,6 @@
 imports:
     - "@SetonoSyliusGoogleAdsPlugin/Resources/config/grids/setono_sylius_google_ads_admin_connection.yaml"
+    - "@SetonoSyliusGoogleAdsPlugin/Resources/config/grids/setono_sylius_google_ads_admin_conversion.yaml"
 
 framework:
     messenger:

--- a/src/Resources/config/grids/setono_sylius_google_ads_admin_connection.yaml
+++ b/src/Resources/config/grids/setono_sylius_google_ads_admin_connection.yaml
@@ -1,4 +1,7 @@
 sylius_grid:
+    templates:
+        action:
+            view_conversions: "@SetonoSyliusGoogleAdsPlugin/grid/action/view_conversions.html.twig"
     grids:
         setono_sylius_google_ads_admin_connection:
             driver:
@@ -18,6 +21,9 @@ sylius_grid:
                 main:
                     create:
                         type: create
+                    view_conversions:
+                        type: view_conversions
+                        label: setono_sylius_google_ads.ui.view_conversions
                 item:
                     update:
                         type: update

--- a/src/Resources/config/grids/setono_sylius_google_ads_admin_conversion.yaml
+++ b/src/Resources/config/grids/setono_sylius_google_ads_admin_conversion.yaml
@@ -1,0 +1,62 @@
+sylius_grid:
+    templates:
+        action:
+            setup_connections: "@SetonoSyliusGoogleAdsPlugin/grid/action/setup_connections.html.twig"
+    grids:
+        setono_sylius_google_ads_admin_conversion:
+            driver:
+                name: doctrine/orm
+                options:
+                    class: "%setono_sylius_google_ads.model.conversion.class%"
+            fields:
+                order:
+                    type: twig
+                    label: sylius.ui.order
+                    path: .
+                    sortable: order.number
+                    options:
+                        template: "@SetonoSyliusGoogleAdsPlugin/conversion/grid/field/order.html.twig"
+                channel:
+                    type: twig
+                    label: sylius.ui.channel
+                    sortable: channel.code
+                    options:
+                        template: "@SyliusAdmin/Order/Grid/Field/channel.html.twig"
+                value:
+                    type: twig
+                    label: sylius.ui.value
+                    path: .
+                    sortable: value
+                    options:
+                        template: "@SetonoSyliusGoogleAdsPlugin/conversion/grid/field/value.html.twig"
+                state:
+                    type: twig
+                    label: sylius.ui.state
+                    sortable: ~
+                    options:
+                        template: "@SyliusUi/Grid/Field/state.html.twig"
+                        vars:
+                            labels: "@SetonoSyliusGoogleAdsPlugin/conversion/label/state"
+                createdAt:
+                    type: datetime
+                    label: sylius.ui.created_at
+                    sortable: ~
+                    options:
+                        format: d-m-Y H:i
+                nextProcessingAt:
+                    type: twig
+                    label: setono_sylius_google_ads.ui.next_processing_at
+                    sortable: ~
+                    options:
+                        template: "@SetonoSyliusGoogleAdsPlugin/grid/field/date.html.twig"
+                logMessages:
+                    type: twig
+                    label: setono_sylius_google_ads.ui.log
+                    path: .
+                    options:
+                        template: "@SetonoSyliusGoogleAdsPlugin/conversion/grid/field/log_messages.html.twig"
+            actions:
+                main:
+                    setup_connections:
+                        type: setup_connections
+                        label: setono_sylius_google_ads.ui.setup_connections

--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -1,3 +1,10 @@
+# Route responsible for redirecting the user to the 'correct' Google Ads page depending on the state of his/her setup
+setono_sylius_google_ads_admin_redirect_main_menu:
+    path: /
+    methods: [GET]
+    defaults:
+        _controller: setono_sylius_google_ads.controller.action.redirect_main_menu
+
 # Setup related routes
 setono_sylius_google_ads_admin_setup_authorize:
     path: /connections/{connectionId}/setup/authorize
@@ -52,6 +59,24 @@ setono_sylius_google_ads_admin_connection:
                 subheader: setono_sylius_google_ads.ui.manage_connections
                 templates:
                     form: "@SetonoSyliusGoogleAdsPlugin/connection/_form.html.twig"
+            index:
+                icon: 'linkify'
+    type: sylius.resource
+    
+# Conversion resource routes
+setono_sylius_google_ads_admin_conversion:
+    resource: |
+        section: admin
+        alias: setono_sylius_google_ads.conversion
+        permission: true
+        templates: '@SyliusAdmin\\Crud'
+        redirect: update
+        grid: setono_sylius_google_ads_admin_conversion
+        vars:
+            all:
+                subheader: setono_sylius_google_ads.ui.manage_conversions
+                templates:
+                    form: "@SetonoSyliusGoogleAdsPlugin/conversion/_form.html.twig"
             index:
                 icon: 'money bill alternate outline'
     type: sylius.resource

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -3,6 +3,12 @@
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="setono_sylius_google_ads.controller.action.redirect_main_menu"
+                 class="Setono\SyliusGoogleAdsPlugin\Controller\Action\RedirectMainMenuAction" public="true">
+            <argument type="service" id="setono_sylius_google_ads.repository.connection"/>
+            <argument type="service" id="router"/>
+        </service>
+
         <!-- Setup related controllers -->
         <service id="setono_sylius_google_ads.controller.action.setup_authorize"
                  class="Setono\SyliusGoogleAdsPlugin\Controller\Action\SetupAuthorizeAction" public="true">

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -15,15 +15,22 @@ setono_sylius_google_ads:
             customer_id: Customer id
             conversion_action_id: Conversion action id
     ui:
-        refresh_token_updated: The access token was updated
         connections: Connections
+        conversions: Conversions
         edit_connection: Edit connection
         enabled: Enabled
         google_ads: Google Ads
+        log: Log
         manage_connections: Manage Google Ads API connections
+        manage_conversions: A list of conversions with a Google Ads click identifier
         new_connection: New connection
+        next_processing_at: Next processing
         no_channels: No channels
+        no_log_messages: No log messages
+        no_value: No value
+        refresh_token_updated: The access token was updated
         setup_connection_with_google_ads: Setup connection with Google Ads
+        setup_connections: Setup connections
         setup:
             authorize:
                 header: "Setup connection: %name%"
@@ -58,3 +65,4 @@ setono_sylius_google_ads:
                         <li>When these steps are completed you will be able to see your client id and client secret on the credentials page</li>
                     </ol>
                 </p>
+        view_conversions: View conversions

--- a/src/Resources/views/conversion/grid/field/log_messages.html.twig
+++ b/src/Resources/views/conversion/grid/field/log_messages.html.twig
@@ -1,0 +1,24 @@
+{# @var data \Setono\SyliusGoogleAdsPlugin\Model\ConversionInterface #}
+
+{% if data.hasLogMessages %}
+    {# TODO: This javascript is ugly. Fix it at some point #}
+    <a href="javascript:void(0)" id="link-show-log-messages-{{ data.id }}">{{ 'sylius.ui.show'|trans }}</a>
+
+    <div class="ui modal" id="modal-{{ data.id }}">
+        <i class="close icon"></i>
+        <div class="header">{{ 'setono_sylius_google_ads.ui.log'|trans }}</div>
+        <div class="content">
+            {{ data.logMessages|join('<br>')|raw }}
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelector('#link-show-log-messages-{{ data.id }}').addEventListener('click', function() {
+                $('#modal-{{ data.id }}').modal('show');
+            });
+        });
+    </script>
+{% else %}
+    <span style="color: grey; font-style: italic">{{ 'setono_sylius_google_ads.ui.no_log_messages'|trans }}</span>
+{% endif %}

--- a/src/Resources/views/conversion/grid/field/order.html.twig
+++ b/src/Resources/views/conversion/grid/field/order.html.twig
@@ -1,0 +1,3 @@
+{# @var data \Setono\SyliusGoogleAdsPlugin\Model\ConversionInterface #}
+
+<a href="{{ path('sylius_admin_order_show', {'id' : data.order.id })|raw }}">#{{ data.order.number }}</a>

--- a/src/Resources/views/conversion/grid/field/value.html.twig
+++ b/src/Resources/views/conversion/grid/field/value.html.twig
@@ -1,0 +1,4 @@
+{# @var data \Setono\SyliusGoogleAdsPlugin\Model\ConversionInterface #}
+{% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
+
+{{ money.format(data.value, data.currencyCode) }}

--- a/src/Resources/views/conversion/label/state/delivered.html.twig
+++ b/src/Resources/views/conversion/label/state/delivered.html.twig
@@ -1,0 +1,4 @@
+<span class="ui green{% if attached is defined and attached == true %} top attached{% endif %} label">
+    <i class="check icon"></i>
+    {{ value|trans }}
+</span>

--- a/src/Resources/views/conversion/label/state/failed.html.twig
+++ b/src/Resources/views/conversion/label/state/failed.html.twig
@@ -1,0 +1,4 @@
+<span class="ui red{% if attached is defined and attached == true %} top attached{% endif %} label">
+    <i class="ban icon"></i>
+    {{ value|trans }}
+</span>

--- a/src/Resources/views/grid/action/setup_connections.html.twig
+++ b/src/Resources/views/grid/action/setup_connections.html.twig
@@ -1,0 +1,3 @@
+{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
+
+{{ buttons.default(path('setono_sylius_google_ads_admin_connection_index'), action.label, null, 'cog') }}

--- a/src/Resources/views/grid/action/view_conversions.html.twig
+++ b/src/Resources/views/grid/action/view_conversions.html.twig
@@ -1,0 +1,3 @@
+{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
+
+{{ buttons.default(path('setono_sylius_google_ads_admin_conversion_index'), action.label, null, 'search') }}

--- a/src/Resources/views/grid/field/date.html.twig
+++ b/src/Resources/views/grid/field/date.html.twig
@@ -1,0 +1,6 @@
+{# @var data \DateTimeImmutable|null #}
+{% if data is null %}
+    <span style="color: grey; font-style: italic">{{ 'setono_sylius_google_ads.ui.no_value'|trans }}</span>
+{% else %}
+    {{ data|date('Y-m-d H:i') }}
+{% endif %}


### PR DESCRIPTION
Added a grid for conversions that looks like this:

<img width="1630" alt="image" src="https://github.com/Setono/SyliusGoogleAdsPlugin/assets/2412177/9cddbbe2-afee-4dc2-a4c0-7201303a7a8a">

___

Clicked the `Show log` link:

<img width="1542" alt="image" src="https://github.com/Setono/SyliusGoogleAdsPlugin/assets/2412177/9bd8055d-1f65-4625-b836-0b6ee3fef6bf">
