### PR TITLE
Fixing Doctrine/PHP type consistency

### DIFF
--- a/src/Controller/Action/SetupMapCustomerIdAction.php
+++ b/src/Controller/Action/SetupMapCustomerIdAction.php
@@ -103,13 +103,13 @@ final class SetupMapCustomerIdAction extends AbstractSetupAction
         ]));
     }
 
-    private function getConversionActionById(GoogleAdsClient $googleAdsClient, int $customerId, int $id): ?ConversionAction
+    private function getConversionActionById(GoogleAdsClient $googleAdsClient, string $customerId, string $id): ?ConversionAction
     {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
 
         /** @var GoogleAdsServerStreamDecorator $stream */
         $stream = $googleAdsServiceClient->searchStream(
-            (string) $customerId,
+            $customerId,
             "SELECT conversion_action.id, conversion_action.status, conversion_action.name, conversion_action.type FROM conversion_action WHERE conversion_action.id = $id",
         );
 
@@ -129,7 +129,7 @@ final class SetupMapCustomerIdAction extends AbstractSetupAction
     /**
      * Creates a conversion action and returns its id
      */
-    private function createConversionAction(GoogleAdsClient $googleAdsClient, int $customerId, string $name, int $type): int
+    private function createConversionAction(GoogleAdsClient $googleAdsClient, string $customerId, string $name, int $type): string
     {
         $name = sprintf('%s [%s]', $name, (new \DateTimeImmutable())->format('Y-m-d H:i'));
 
@@ -147,7 +147,7 @@ final class SetupMapCustomerIdAction extends AbstractSetupAction
         // Issues a mutate request to add the conversion action.
         $conversionActionServiceClient = $googleAdsClient->getConversionActionServiceClient();
         $response = $conversionActionServiceClient->mutateConversionActions(
-            (string) $customerId,
+            $customerId,
             [$conversionActionOperation],
             ['responseContentType' => ResponseContentType::MUTABLE_RESOURCE],
         );
@@ -159,7 +159,7 @@ final class SetupMapCustomerIdAction extends AbstractSetupAction
                 continue;
             }
 
-            return (int) $conversionAction->getId();
+            return (string) $conversionAction->getId();
         }
 
         throw new \RuntimeException('Could not create conversion action');

--- a/src/ConversionProcessor/ConversionProcessor.php
+++ b/src/ConversionProcessor/ConversionProcessor.php
@@ -64,7 +64,7 @@ final class ConversionProcessor implements ConversionProcessorInterface
 
         $preSetClickConversionDataEvent = new PreSetClickConversionDataEvent($conversion, [
             'conversion_action' => ResourceNames::forConversionAction(
-                (string) $customerId,
+                $customerId,
                 (string) $connectionMapping->getConversionActionId(),
             ),
             'conversion_value' => round((int) $conversion->getValue() / 100, 2),
@@ -87,7 +87,7 @@ final class ConversionProcessor implements ConversionProcessorInterface
         $conversionUploadServiceClient = $client->getConversionUploadServiceClient();
 
         $response = $conversionUploadServiceClient->uploadClickConversions(
-            (string) $customerId,
+            $customerId,
             [$clickConversion],
             true, // notice that we only add one operation so in practice it's not a partial error, but just an error
         );

--- a/src/Factory/GoogleAdsClientFactory.php
+++ b/src/Factory/GoogleAdsClientFactory.php
@@ -18,7 +18,7 @@ final class GoogleAdsClientFactory implements GoogleAdsClientFactoryInterface
         string $clientSecret,
         string $refreshToken,
         string $developerToken,
-        int $managerId = null,
+        string $managerId = null,
         LoggerInterface $logger = null,
     ): GoogleAdsClient {
         $tokenBuilder = (new OAuth2TokenBuilder())
@@ -29,7 +29,7 @@ final class GoogleAdsClientFactory implements GoogleAdsClientFactoryInterface
         $builder = (new GoogleAdsClientBuilder())
             ->withDeveloperToken($developerToken)
             ->withOAuth2Credential($tokenBuilder->build())
-            ->withLoginCustomerId($managerId)
+            ->withLoginCustomerId((int) $managerId)
         ;
 
         if (null !== $logger) {
@@ -43,7 +43,7 @@ final class GoogleAdsClientFactory implements GoogleAdsClientFactoryInterface
 
     public function createFromConnection(
         ConnectionInterface $connection,
-        int $managerId = null,
+        string $managerId = null,
         LoggerInterface $logger = null,
     ): GoogleAdsClient {
         return $this->create(

--- a/src/Factory/GoogleAdsClientFactoryInterface.php
+++ b/src/Factory/GoogleAdsClientFactoryInterface.php
@@ -15,13 +15,13 @@ interface GoogleAdsClientFactoryInterface
         string $clientSecret,
         string $refreshToken,
         string $developerToken,
-        int $managerId = null,
+        string $managerId = null,
         LoggerInterface $logger = null,
     ): GoogleAdsClient;
 
     public function createFromConnection(
         ConnectionInterface $connection,
-        int $managerId = null,
+        string $managerId = null,
         LoggerInterface $logger = null,
     ): GoogleAdsClient;
 }

--- a/src/Form/Type/CustomerIdChoiceType.php
+++ b/src/Form/Type/CustomerIdChoiceType.php
@@ -31,8 +31,8 @@ final class CustomerIdChoiceType extends AbstractType
 
                     return $this->customerIdsResolver->getCustomerIdsFromConnection($connection);
                 },
-                'choice_value' => static fn (mixed $customerId): ?int => match (true) {
-                    null === $customerId || is_int($customerId) => $customerId,
+                'choice_value' => static fn (mixed $customerId): ?string => match (true) {
+                    null === $customerId || is_string($customerId) => $customerId,
                     $customerId instanceof CustomerId => $customerId->customerId,
                     default => throw new \RuntimeException('Invalid input')
                 },

--- a/src/Model/ConnectionMapping.php
+++ b/src/Model/ConnectionMapping.php
@@ -15,11 +15,11 @@ class ConnectionMapping implements ConnectionMappingInterface
 
     private ?ChannelInterface $channel = null;
 
-    private ?int $managerId = null;
+    private ?string $managerId = null;
 
-    private ?int $customerId = null;
+    private ?string $customerId = null;
 
-    private ?int $conversionActionId = null;
+    private ?string $conversionActionId = null;
 
     public function getId(): ?int
     {
@@ -46,22 +46,22 @@ class ConnectionMapping implements ConnectionMappingInterface
         $this->channel = $channel;
     }
 
-    public function getManagerId(): ?int
+    public function getManagerId(): ?string
     {
         return $this->managerId;
     }
 
-    public function setManagerId(?int $managerId): void
+    public function setManagerId(?string $managerId): void
     {
         $this->managerId = $managerId;
     }
 
-    public function getCustomerId(): ?int
+    public function getCustomerId(): ?string
     {
         return $this->customerId;
     }
 
-    public function setCustomerId(null|int|CustomerId $customerId): void
+    public function setCustomerId(null|string|CustomerId $customerId): void
     {
         if ($customerId instanceof CustomerId) {
             $this->setManagerId($customerId->managerId);
@@ -71,12 +71,12 @@ class ConnectionMapping implements ConnectionMappingInterface
         $this->customerId = $customerId;
     }
 
-    public function getConversionActionId(): ?int
+    public function getConversionActionId(): ?string
     {
         return $this->conversionActionId;
     }
 
-    public function setConversionActionId(null|int $conversionActionId): void
+    public function setConversionActionId(?string $conversionActionId): void
     {
         $this->conversionActionId = $conversionActionId;
     }

--- a/src/Model/ConnectionMappingInterface.php
+++ b/src/Model/ConnectionMappingInterface.php
@@ -16,15 +16,15 @@ interface ConnectionMappingInterface extends ResourceInterface, ChannelAwareInte
 
     public function setConnection(?ConnectionInterface $connection): void;
 
-    public function getManagerId(): ?int;
+    public function getManagerId(): ?string;
 
-    public function setManagerId(?int $managerId): void;
+    public function setManagerId(?string $managerId): void;
 
-    public function getCustomerId(): ?int;
+    public function getCustomerId(): ?string;
 
-    public function setCustomerId(null|int|CustomerId $customerId): void;
+    public function setCustomerId(null|string|CustomerId $customerId): void;
 
-    public function getConversionActionId(): ?int;
+    public function getConversionActionId(): ?string;
 
-    public function setConversionActionId(?int $conversionActionId): void;
+    public function setConversionActionId(?string $conversionActionId): void;
 }

--- a/src/Resolver/CustomerId.php
+++ b/src/Resolver/CustomerId.php
@@ -6,7 +6,10 @@ namespace Setono\SyliusGoogleAdsPlugin\Resolver;
 
 final class CustomerId
 {
-    public function __construct(public readonly string $label, public readonly int $managerId, public readonly int $customerId)
-    {
+    public function __construct(
+        public readonly string $label,
+        public readonly string $managerId,
+        public readonly string $customerId,
+    ) {
     }
 }

--- a/tests/LiveTestTrait.php
+++ b/tests/LiveTestTrait.php
@@ -19,20 +19,20 @@ trait LiveTestTrait
         return is_string($live) && true === (bool) $live;
     }
 
-    public static function getManagerId(): int
+    public static function getManagerId(): string
     {
         $managerId = getenv('GOOGLE_ADS_MANAGER_ID');
         Assert::stringNotEmpty($managerId);
 
-        return (int) $managerId;
+        return $managerId;
     }
 
-    public static function getCustomerId(): int
+    public static function getCustomerId(): string
     {
         $customerId = getenv('GOOGLE_ADS_CUSTOMER_ID');
         Assert::stringNotEmpty($customerId);
 
-        return (int) $customerId;
+        return $customerId;
     }
 
     public static function createConnection(): ConnectionInterface


### PR DESCRIPTION
Some of the properties in the `Conversion` entity has the `bigint` Doctrine type which is converted to a `string` in PHP. Before this PR these properties were represented as `int`s.